### PR TITLE
Use Plugin as PlayModule

### DIFF
--- a/examples/play-2.4-elastic-template/app/controllers/JavaController.java
+++ b/examples/play-2.4-elastic-template/app/controllers/JavaController.java
@@ -18,9 +18,6 @@ import java.util.List;
  */
 public class JavaController extends Controller {
 
-  @Inject
-  ElasticPlugin elasticPlugin;
-
   public Result index() {
 
     final WorldRepository worldRepository = ElasticServiceProviderImpl.get().worldRepository;

--- a/examples/play-2.4-elastic-template/app/modules/ElasticModule.java
+++ b/examples/play-2.4-elastic-template/app/modules/ElasticModule.java
@@ -1,0 +1,12 @@
+package modules;
+
+import com.google.inject.AbstractModule;
+import elasticplugin.ElasticPlugin;
+
+public class ElasticModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(ElasticPlugin.class).asEagerSingleton();
+    }
+}

--- a/examples/play-2.4-elastic-template/conf/application.conf
+++ b/examples/play-2.4-elastic-template/conf/application.conf
@@ -14,6 +14,10 @@ play.crypto.secret = "changeme"
 # ~~~~~
 play.i18n.langs = [ "en" ]
 
+# Modules
+# ~~~~~
+play.modules.enabled += "modules.ElasticModule"
+
 # Router
 # ~~~~~
 # Define the Router object to use for this application.

--- a/src/main/java/elasticplugin/ElasticServiceProvider.java
+++ b/src/main/java/elasticplugin/ElasticServiceProvider.java
@@ -27,5 +27,5 @@ import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
 public class ElasticServiceProvider {
 
   @Autowired
-  ElasticsearchTemplate template;
+  public ElasticsearchTemplate template;
 }


### PR DESCRIPTION
Added the ability to eagerly load the plugin with application startup. This means you don't have to initialise the module using `@inject ElasticPlugin elasticPlugin` in your controllers. 
